### PR TITLE
Added link to devpost on view judged project page

### DIFF
--- a/client/src/pages/judge/project.tsx
+++ b/client/src/pages/judge/project.tsx
@@ -10,16 +10,16 @@ import Ratings from '../../components/judge/Ratings';
 
 const Project = () => {
     const { id } = useParams();
-    const [project, setProject] = useState<null | JudgedProject>(null);
+    const [project, setProject] = useState<null | JudgedProjectWithUrl>(null);
 
     useEffect(() => {
         async function fetchData() {
-            const projRes = await getRequest<JudgedProject>(`/judge/project/${id}`, 'judge');
+            const projRes = await getRequest<JudgedProjectWithUrl>(`/judge/project/${id}`, 'judge');
             if (projRes.status !== 200) {
                 errorAlert(projRes);
                 return;
             }
-            const proj = projRes.data as JudgedProject;
+            const proj = projRes.data as JudgedProjectWithUrl;
             setProject(proj);
         }
 
@@ -33,9 +33,27 @@ const Project = () => {
             <JuryHeader withLogout />
             <Container noCenter={true} className="px-2">
                 <Back location="/judge" />
-                <h1 className="text-3xl mb-1">{project.name}</h1>
+                <h1 className="text-3xl mb-1 font-bold">
+                    <a
+                        href={project.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:text-primary duration-200"
+                    >
+                        {project.name}
+                    </a>
+                </h1>
                 <h2 className="text-xl font-bold text-light mb-2">Table {project.location}</h2>
-                <Ratings callback={() => {alert('Ratings submitted!'                )}} prior={project.categories} project={project} small submitText="Update" update />
+                <Ratings
+                    callback={() => {
+                        alert('Ratings submitted!');
+                    }}
+                    prior={project.categories}
+                    project={project}
+                    small
+                    submitText="Update"
+                    update
+                />
                 <Paragraph text={project.description} className="text-light" />
             </Container>
         </>

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -79,6 +79,10 @@ interface JudgedProject {
     description: string;
 }
 
+type JudgedProjectWithUrl = {
+    url: string;
+} & JudgedProject;
+
 type SortableJudgedProject = {
     id: number;
 } & JudgedProject;


### PR DESCRIPTION
### Description

On the "view judged project" page, clicking on the title now links to Devpost.

### Fixes #112 

### Type of Change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Is this a breaking change?

- [ ] Yes
- [X] No
