### PR TITLE
fix: automatically reset "busy" status for projects after judging

### DIFF
--- a/server/database/judge.go
+++ b/server/database/judge.go
@@ -180,3 +180,26 @@ func UpdateJudgeSeenProjects(db *mongo.Database, judge *models.Judge) error {
 	_, err := db.Collection("judges").UpdateOne(context.Background(), gin.H{"_id": judge.Id}, gin.H{"$set": gin.H{"seen_projects": judge.SeenProjects}})
 	return err
 }
+
+// Reset list of projects that judge skipped due to busy
+func ResetBusyProjectListForJudge(db *mongo.Database, judge *models.Judge) error {
+	_, err := db.Collection("flags").DeleteMany(context.Background(), gin.H{
+		"judge_id": judge.Id,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Reset project status to non-busy by deleting all "busy" flag for a project
+func ResetBusyStatusByProject(db *mongo.Database, project *models.Project) error {
+	_, err := db.Collection("flags").DeleteMany(context.Background(), gin.H{
+		"project_id": project.Id,
+		"reason":     "busy",
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/judging/judging_flow.go
+++ b/server/judging/judging_flow.go
@@ -65,6 +65,10 @@ func SkipCurrentProject(db *mongo.Database, judge *models.Judge, comps *Comparis
 			return nil, err
 		}
 
+		if project == nil {
+			return nil, nil
+		}
+
 		// Update the judge
 		return database.UpdateAfterPickedWithTx(db, project, judge, ctx)
 	})
@@ -153,9 +157,7 @@ func FindPreferredItems(db *mongo.Database, judge *models.Judge, ctx mongo.Sessi
 		done[proj.ProjectId.Hex()] = true
 	}
 	for _, flag := range flags {
-		if flag.Reason != "busy" {
-			done[flag.ProjectId.Hex()] = true
-		}
+		done[flag.ProjectId.Hex()] = true
 	}
 
 	// Filter out all projects that the judge has skipped or voted on

--- a/server/router/judge.go
+++ b/server/router/judge.go
@@ -571,6 +571,22 @@ func JudgeScore(ctx *gin.Context) {
 		return
 	}
 
+	// Reset list of skipped projects due to busy status
+	err = database.ResetBusyProjectListForJudge(db, judge)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{
+			"error": "error resetting busy project list in database: " + err.Error(),
+		})
+	}
+
+	// "Remove" busy status from current project so that other judges can come back to that project
+	err = database.ResetBusyStatusByProject(db, project)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{
+			"error": "error resetting busy project status in database: " + err.Error(),
+		})
+	}
+
 	// Send OK
 	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
 }


### PR DESCRIPTION
### Description

Fixed the issue with judges keep seeing "busy" projects. This is accomplished by implementation to do the following: 
- Resetting the list of recently busy projects of a judge after they found a non-busy project by deleting all "busy" flags associated to the judge. 
- After a judge submits a score for a project, all "busy" flags associated to that project will be removed.  

### Fixes #133 

### Type of Change
- Bug fix (change which fixes an issue)

### Is this a breaking change?

- [ ] Yes
- [x] No
