### PR TITLE
Fixed issue where judge export is wrong

### DIFF
--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -721,7 +721,7 @@ const AdminSettings = () => {
                 <SubSection>Export Collection</SubSection>
                 <Description>Export each collection individually as a CSV download.</Description>
                 <div className="flex">
-                    <SettingsButton onClick={() => exportCsv('users')} className="mr-4">
+                    <SettingsButton onClick={() => exportCsv('judges')} className="mr-4">
                         Export Judges
                     </SettingsButton>
                     <SettingsButton onClick={() => exportCsv('projects')} className="mr-4">


### PR DESCRIPTION
### Description

For some reason the judge export was calling /admin/export/users, but it should've been /admin/export/judges.

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)

### Is this a breaking change?

- [ ] Yes
- [X] No
