### PR TITLE
Judge and project stats update when added

### DIFF
--- a/client/src/components/admin/add-judges/AddJudgeStatsPanel.tsx
+++ b/client/src/components/admin/add-judges/AddJudgeStatsPanel.tsx
@@ -1,29 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import StatBlock from '../../StatBlock';
-import { getRequest } from '../../../api';
-import { errorAlert } from '../../../util';
-
-interface JudgeStats {
-    num: number;
-    avg_seen: number;
-    num_active: number;
-}
+import { useAdminStore } from '../../../store';
 
 const AddJudgeStatsPanel = () => {
-    const [stats, setStats] = useState<JudgeStats>({ num: 0, avg_seen: 0, num_active: 0 });
-    useEffect(() => {
-        const fetchStats = async () => {
-            const res = await getRequest('/judge/stats', 'admin');
-            if (res.status === 500) {
-                return;
-            }
-            if (res.status !== 200) {
-                errorAlert(res);
-                return;
-            }
-            setStats(res.data as JudgeStats);
-        };
+    const stats = useAdminStore((state) => state.judgeStats);
+    const fetchStats = useAdminStore((state) => state.fetchJudgeStats);
 
+    useEffect(() => {
         fetchStats();
     }, []);
 

--- a/client/src/components/admin/add-judges/NewJudgeForm.tsx
+++ b/client/src/components/admin/add-judges/NewJudgeForm.tsx
@@ -6,6 +6,7 @@ import { postRequest } from '../../../api';
 import { errorAlert } from '../../../util';
 import Checkbox from '../../Checkbox';
 import Loading from '../../Loading';
+import { useAdminStore } from '../../../store';
 
 interface NewJudgeData {
     name: string;
@@ -20,6 +21,7 @@ const NewJudgeForm = () => {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const { register, handleSubmit, reset } = useForm<NewJudgeData>();
     const [noSend, setNoSend] = useState(false);
+    const fetchJudgeStats = useAdminStore((state) => state.fetchJudgeStats);
 
     const onSubmit: SubmitHandler<NewJudgeData> = async (data) => {
         setIsSubmitting(true);
@@ -35,6 +37,7 @@ const NewJudgeForm = () => {
 
         alert('Judge added successfully!');
         reset();
+        fetchJudgeStats();
         setIsSubmitting(false);
     };
 

--- a/client/src/components/admin/add-judges/UploadCSVForm.tsx
+++ b/client/src/components/admin/add-judges/UploadCSVForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { createHeaders } from '../../../api';
 import Loading from '../../Loading';
+import { useAdminStore } from '../../../store';
 
 interface UploadCSVFormProps {
     /* The format of the CSV file */
@@ -14,6 +15,8 @@ const UploadCSVForm = (props: UploadCSVFormProps) => {
     const [error, setError] = useState<string | null>();
     const [msg, setMsg] = useState<string | null>();
     const [isUploading, setIsUploading] = useState<boolean>(false);
+    const fetchJudgeStats = useAdminStore((state) => state.fetchJudgeStats);
+    const fetchProjectStats = useAdminStore((state) => state.fetchProjectStats);
 
     // Handle file drag and drop
     const handleDrop: React.DragEventHandler<HTMLDivElement> = (e) => {
@@ -79,6 +82,7 @@ const UploadCSVForm = (props: UploadCSVFormProps) => {
             setIsUploading(false);
         }
 
+        props.format === 'judge' ? fetchJudgeStats() : fetchProjectStats();
         setIsUploading(false);
     };
 
@@ -106,7 +110,7 @@ const UploadCSVForm = (props: UploadCSVFormProps) => {
                             onDragOver={(e) => e.preventDefault()}
                         >
                             <label
-                                htmlFor={"dropzone-file-"+props.format}
+                                htmlFor={'dropzone-file-' + props.format}
                                 className={`flex flex-col items-center justify-center w-full border-2 border-dashed rounded-sm cursor-pointer 
                                 ${
                                     error
@@ -126,7 +130,7 @@ const UploadCSVForm = (props: UploadCSVFormProps) => {
                                     </p>
                                 </div>
                                 <input
-                                    id={"dropzone-file-"+props.format}
+                                    id={'dropzone-file-' + props.format}
                                     type="file"
                                     className="hidden"
                                     onChange={(e) => {
@@ -135,8 +139,8 @@ const UploadCSVForm = (props: UploadCSVFormProps) => {
                                             setFileName(e.target.files[0].name);
                                             setError(null);
                                             setMsg(null);
-                                            
-                                            console.log(props.format)
+
+                                            console.log(props.format);
                                         }
                                     }}
                                 />

--- a/client/src/components/admin/add-projects/AddProjectsStatsPanel.tsx
+++ b/client/src/components/admin/add-projects/AddProjectsStatsPanel.tsx
@@ -1,29 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import StatBlock from '../../StatBlock';
-import { getRequest } from '../../../api';
-import { errorAlert } from '../../../util';
-
-interface ProjectStats {
-    num: number;
-    avg_votes: number;
-    avg_seen: number;
-}
+import { useAdminStore } from '../../../store';
 
 const AddProjectsStatsPanel = () => {
-    const [stats, setStats] = useState<ProjectStats>({ num: 0, avg_votes: 0, avg_seen: 0 });
-    useEffect(() => {
-        const fetchStats = async () => {
-            const res = await getRequest('/project/stats', 'admin');
-            if (res.status === 500) {
-                return;
-            }
-            if (res.status !== 200) {
-                errorAlert(res);
-                return;
-            }
-            setStats(res.data as ProjectStats);
-        };
+    const stats = useAdminStore((state) => state.projectStats);
+    const fetchStats = useAdminStore((state) => state.fetchProjectStats);
 
+    useEffect(() => {
         fetchStats();
     }, []);
 

--- a/client/src/components/admin/add-projects/NewProjectForm.tsx
+++ b/client/src/components/admin/add-projects/NewProjectForm.tsx
@@ -4,6 +4,7 @@ import TextArea from '../../TextArea';
 import { useState } from 'react';
 import { postRequest } from '../../../api';
 import { errorAlert } from '../../../util';
+import { useAdminStore } from '../../../store';
 
 interface NewProjectData {
     name: string;
@@ -17,6 +18,7 @@ interface NewProjectData {
 const NewProjectForm = () => {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const { register, handleSubmit, reset } = useForm<NewProjectData>();
+    const fetchProjectStats = useAdminStore((state) => state.fetchProjectStats);
 
     const onSubmit: SubmitHandler<NewProjectData> = async (data) => {
         // Upload project
@@ -36,6 +38,7 @@ const NewProjectForm = () => {
 
         alert('Project added successfully!');
         reset();
+        fetchProjectStats();
         setIsSubmitting(false);
     };
 

--- a/client/src/store.tsx
+++ b/client/src/store.tsx
@@ -9,6 +9,10 @@ interface AdminStore {
     fetchProjects: () => Promise<void>;
     judges: Judge[];
     fetchJudges: () => Promise<void>;
+    judgeStats: JudgeStats;
+    fetchJudgeStats: () => Promise<void>;
+    projectStats: ProjectStats;
+    fetchProjectStats: () => Promise<void>;
 }
 
 const useAdminStore = create<AdminStore>()((set) => ({
@@ -69,6 +73,36 @@ const useAdminStore = create<AdminStore>()((set) => ({
             return;
         }
         set({ judges: judgeRes.data as Judge[] });
+    },
+
+    judgeStats: {
+        num: 0,
+        avg_seen: 0,
+        num_active: 0,
+    },
+
+    fetchJudgeStats: async () => {
+        const statsRes = await getRequest<JudgeStats>('/judge/stats', 'admin');
+        if (statsRes.status !== 200) {
+            errorAlert(statsRes);
+            return;
+        }
+        set({ judgeStats: statsRes.data as JudgeStats });
+    },
+
+    projectStats: {
+        num: 0,
+        avg_seen: 0,
+        avg_votes: 0,
+    },
+
+    fetchProjectStats: async () => {
+        const statsRes = await getRequest<ProjectStats>('/project/stats', 'admin');
+        if (statsRes.status !== 200) {
+            errorAlert(statsRes);
+            return;
+        }
+        set({ projectStats: statsRes.data as ProjectStats });
     },
 }));
 

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -154,3 +154,15 @@ interface ScoredItem {
     id: string;
     score: number;
 }
+
+interface JudgeStats {
+    num: number;
+    avg_seen: number;
+    num_active: number;
+}
+
+interface ProjectStats {
+    num: number;
+    avg_votes: number;
+    avg_seen: number;
+}


### PR DESCRIPTION
### Description

Moved the stats to the global zustand store and call the relevant functions to update them when the respective resource is added.

### Fixes #176 

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)

### Is this a breaking change?

- [ ] Yes
- [X] No
