### PR TITLE
Switch group and table number on expo print view

### DIFF
--- a/client/src/pages/Expo.tsx
+++ b/client/src/pages/Expo.tsx
@@ -86,16 +86,16 @@ const Expo = () => {
                 <table className="table-fixed">
                     <thead className="text-left">
                         <tr>
-                            <th className="pr-2">Table</th>
                             <th className="pr-2">Group</th>
+                            <th className="pr-2">Table</th>
                             <th className="pr-2">Name</th>
                         </tr>
                     </thead>
                     <tbody>
                         {projects.map((project, idx) => (
                             <tr key={idx}>
-                                <td className="pr-2">{project.location}</td>
                                 <td className="pr-2">{groupNames[project.group]}</td>
+                                <td className="pr-2">{project.location}</td>
                                 <td className="pr-2">{project.name}</td>
                             </tr>
                         ))}


### PR DESCRIPTION
### Description

The expo print table now has the following: group, table, project name

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)

### Is this a breaking change?

- [ ] Yes
- [X] No
