### PR TITLE
Remove break button

### DIFF
--- a/client/src/components/admin/tables/JudgeRow.tsx
+++ b/client/src/components/admin/tables/JudgeRow.tsx
@@ -24,6 +24,7 @@ const JudgeRow = ({ judge, idx }: JudgeRowProps) => {
     const selectedTrack = useOptionsStore((state) => state.selectedTrack);
     const selected = useAdminTableStore((state) => state.selected);
     const setSelected = useAdminTableStore((state) => state.setSelected);
+    const projects = useAdminStore((state) => state.projects);
 
     useEffect(() => {
         function closeClick(event: MouseEvent) {
@@ -59,14 +60,13 @@ const JudgeRow = ({ judge, idx }: JudgeRowProps) => {
         fetchJudges();
     };
 
-    const getBestRanked = (judge: Judge) => {
-        if (judge.rankings.length === 0) {
-            return 'N/A';
+    const idToProj = (id: string) => {
+        if (!id || id === '') {
+            return 'None';
         }
 
-        const best = judge.rankings[0];
-        const bestName = judge.seen_projects.find((p) => p.project_id === best)?.name;
-        return bestName ? bestName : best;
+        const proj = projects.find((p) => p.id === id);
+        return proj ? `${proj.name} [T${proj.location}]` : 'None';
     };
 
     return (
@@ -95,7 +95,7 @@ const JudgeRow = ({ judge, idx }: JudgeRowProps) => {
                     <td className="text-center">{judge.group}</td>
                 )}
                 <td className="text-center">{judge.seen}</td>
-                <td className="text-center">{getBestRanked(judge)}</td>
+                <td className="text-center">{idToProj(judge.current)}</td>
                 <td className="text-center">{timeSince(judge.last_activity)}</td>
                 <td className="text-right font-bold flex align-center justify-end">
                     <ActionsDropdown

--- a/client/src/components/admin/tables/JudgesTable.tsx
+++ b/client/src/components/admin/tables/JudgesTable.tsx
@@ -87,11 +87,11 @@ const JudgesTable = () => {
             case JudgeSortField.Seen:
                 sortFunc = (a, b) => (a.seen - b.seen) * asc;
                 break;
-            case JudgeSortField.Top:
-                sortFunc = (a, b) => (a.rankings.length - b.rankings.length) * asc;
-                break;
             case JudgeSortField.Updated:
                 sortFunc = (a, b) => (a.last_activity - b.last_activity) * asc;
+                break;
+            case JudgeSortField.Curr:
+                sortFunc = (a, b) => a.current.localeCompare(b.current) * asc;
                 break;
         }
         setJudges(filteredJudges.toSorted(sortFunc));
@@ -131,9 +131,9 @@ const JudgesTable = () => {
                             sortState={sortState}
                         />
                         <HeaderEntry
-                            name="Best Proj"
+                            name="Curr Proj"
                             updateSort={updateSort}
-                            sortField={JudgeSortField.Top}
+                            sortField={JudgeSortField.Curr}
                             sortState={sortState}
                         />
                         <HeaderEntry

--- a/client/src/enums.ts
+++ b/client/src/enums.ts
@@ -4,8 +4,8 @@ export enum JudgeSortField {
     Track,
     Group,
     Seen,
-    Top,
     Updated,
+    Curr,
     None,
 }
 

--- a/client/src/pages/judge/index.tsx
+++ b/client/src/pages/judge/index.tsx
@@ -80,31 +80,7 @@ const Judge = () => {
         fetchData();
     }, []);
 
-    if (!loaded) return <Loading disabled={!loaded} />;
-
-    // Lets the user take a break
-    const takeBreak = async () => {
-        if (!judge) {
-            alert('You are not logged in!');
-            return;
-        }
-
-        // Check if the user is allowed to take a break
-        if (judge.current == null) {
-            alert('You are already taking a break!');
-            return;
-        }
-
-        const res = await postRequest<OkResponse>('/judge/break', 'judge', null);
-        if (res.status !== 200) {
-            errorAlert(res);
-            return;
-        }
-
-        alert('You can now take a break! Press "Next project" to continue judging.');
-    };
-
-    if (!judge) return <Loading disabled={!judge} />;
+    if (!loaded || !judge) return <Loading disabled={!loaded || !judge} />;
 
     return (
         <>
@@ -121,11 +97,6 @@ const Judge = () => {
                     <Button type="primary" full href="/judge/live">
                         Next Project
                     </Button>
-                    <div className="flex align-center justify-center mt-4">
-                        <Button type="outline" onClick={takeBreak} className="text-lg p-2">
-                            I want to take a break!
-                        </Button>
-                    </div>
                 </div>
                 <div className="flex justify-evenly">
                     <StatBlock name="Seen" value={judge.seen_projects.length as number} />


### PR DESCRIPTION
### Description

Removed the "I want to take a break" button as its mostly useless now. Added a column on the admin dashboard that lets admins see the judges' current project (we can use this to see the projects that they are stuck on potentially).

### Fixes #134 (obsolete)

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)

### Is this a breaking change?

- [ ] Yes
- [X] No
