### PR TITLE
Fixed issue with trailing slash on stats fetch

### DIFF
--- a/client/src/store.tsx
+++ b/client/src/store.tsx
@@ -25,7 +25,8 @@ const useAdminStore = create<AdminStore>()((set) => ({
 
     fetchStats: async () => {
         const selectedTrack = useOptionsStore.getState().selectedTrack;
-        const statsRes = await getRequest<Stats>(`/admin/stats/${selectedTrack}`, 'admin');
+        const slash = selectedTrack === '' ? '' : '/';
+        const statsRes = await getRequest<Stats>(`/admin/stats${slash}${selectedTrack}`, 'admin');
         if (statsRes.status !== 200) {
             errorAlert(statsRes);
             return;
@@ -143,6 +144,11 @@ const useOptionsStore = create<OptionsStore>((set) => ({
         switching_mode: '',
         auto_switch_prop: 0,
         manual_switches: 0,
+        deliberation: false,
+        group_names: [],
+        ignore_tracks: [],
+        block_reqs: false,
+        max_req_per_min: 0
     },
 
     selectedTrack: '',


### PR DESCRIPTION
### Description

For some reason, the trailing slash on the route for `/api/admin/stats[/]` will break the route (bc of how Gin does its route matching). So added some frontend code to make sure that won't happen. We should also document this issue and ensure no frontend engineer will add a trailing slash in the future to route calls.

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)

### Is this a breaking change?

- [ ] Yes
- [X] No
