### PR TITLE
Fixed z-index issue with actions dropdown

### DIFF
--- a/client/src/components/ActionsDropdown.tsx
+++ b/client/src/components/ActionsDropdown.tsx
@@ -54,7 +54,7 @@ const ActionsDropdown = (props: ActionsDropdownProps) => {
     return (
         <div
             className={twMerge(
-                'absolute flex flex-col bg-background rounded-md border-lightest border-2 font-normal text-sm',
+                'absolute flex flex-col bg-background rounded-md border-lightest border-2 font-normal text-sm z-10',
                 props.large && 'text-lg',
                 props.className
             )}


### PR DESCRIPTION
### Description

![image](https://github.com/user-attachments/assets/0dc795c9-6c58-4fe4-9c96-d6dfa285ada3)

Actions dropdown now goes over return to top button

### Fixes #249 

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)

### Is this a breaking change?

- [ ] Yes
- [x] No
