### PR TITLE
Project now assigned only when judge goes to next project

### DIFF
--- a/client/src/components/judge/popups/VotePopup.tsx
+++ b/client/src/components/judge/popups/VotePopup.tsx
@@ -1,6 +1,5 @@
 import Button from '../../Button';
 import Popup from '../../Popup';
-import { useNavigate } from 'react-router-dom';
 import Star from '../Star';
 import TextArea from '../../TextArea';
 
@@ -35,13 +34,10 @@ interface FinishPopupProps {
  * Component to show when the user clicks the "Submit" button
  */
 const FinishPopup = (props: FinishPopupProps) => {
-    const navigate = useNavigate();
-
     if (!props.enabled) return null;
 
     const done = async () => {
         await props.callback();
-        navigate('/judge');
     };
 
     return (

--- a/client/src/pages/judge/index.tsx
+++ b/client/src/pages/judge/index.tsx
@@ -95,7 +95,7 @@ const Judge = () => {
                 )}
                 <div className="w-full mb-6 mt-2">
                     <Button type="primary" full href="/judge/live">
-                        Next Project
+                        {judge.current !== null ? 'Resume Project' : 'Next Project'}
                     </Button>
                 </div>
                 <div className="flex justify-evenly">

--- a/client/src/pages/judge/live.tsx
+++ b/client/src/pages/judge/live.tsx
@@ -245,22 +245,22 @@ const JudgeLive = () => {
         setPaused(true);
     };
 
-    const actionCallback = async (isVote?: boolean) => {
+    const actionCallback = async () => {
         setJudge(null);
-
-        // Call update endpoint if voting
-        if (isVote) {
-            const res = await postRequest<OkResponse>('/judge/score', 'judge', {
-                notes,
-                starred,
-            });
-            if (res.status !== 200) {
-                errorAlert(res);
-            }
-        }
-
         resetTimer();
         getJudgeData();
+    };
+
+    const finishJudging = async () => {
+        const res = await postRequest<OkResponse>('/judge/finish', 'judge', {
+            notes,
+            starred,
+        });
+        if (res.status !== 200) {
+            errorAlert(res);
+        }
+
+        navigate('/judge');
     };
 
     // Display an error page if an error condition holds
@@ -418,7 +418,7 @@ const JudgeLive = () => {
                     enabled={finishPopup}
                     setEnabled={setFinishPopup}
                     judge={judge}
-                    callback={actionCallback.bind(this, true)}
+                    callback={finishJudging}
                     notes={notes}
                     setNotes={setNotes}
                     starred={starred}

--- a/server/router/init.go
+++ b/server/router/init.go
@@ -147,7 +147,7 @@ func NewRouter(db *mongo.Database, logger *logging.Logger) *gin.Engine {
 	judgeRouter.GET("/judge/projects", GetJudgeProjects)
 	judgeRouter.POST("/judge/next", GetNextJudgeProject)
 	judgeRouter.POST("/judge/skip", JudgeSkip)
-	judgeRouter.POST("/judge/score", JudgeScore)
+	judgeRouter.POST("/judge/finish", JudgeFinish)
 	judgeRouter.POST("/judge/rank", JudgeRank)
 	judgeRouter.PUT("/judge/star/:id", JudgeStar)
 	judgeRouter.POST("/judge/break", JudgeBreak)

--- a/server/router/judge.go
+++ b/server/router/judge.go
@@ -640,8 +640,8 @@ type JudgeScoreRequest struct {
 	Starred bool   `json:"starred"`
 }
 
-// POST /judge/score - Endpoint to finish judging a project
-func JudgeScore(ctx *gin.Context) {
+// POST /judge/finish - Endpoint to finish judging a project
+func JudgeFinish(ctx *gin.Context) {
 	// Get the state from the context
 	state := GetState(ctx)
 


### PR DESCRIPTION
### Description

See issue; but now a new project will only be assigned when the judge wants to start judging the next project.

### Fixes #179 

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)

### Is this a breaking change?

- [ ] Yes
- [x] No
