### PR TITLE
Removed take a break API endpoint

### DIFF
--- a/server/router/init.go
+++ b/server/router/init.go
@@ -152,7 +152,6 @@ func NewRouter(db *mongo.Database, logger *logging.Logger) *gin.Engine {
 	judgeRouter.POST("/judge/finish", JudgeFinish)
 	judgeRouter.POST("/judge/rank", JudgeRank)
 	judgeRouter.PUT("/judge/star/:id", JudgeStar)
-	judgeRouter.POST("/judge/break", JudgeBreak)
 	judgeRouter.PUT("/judge/notes/:id", JudgeUpdateNotes)
 	judgeRouter.GET("/project/:id", GetProject)
 	judgeRouter.GET("/project/count", GetProjectCount)

--- a/server/router/judge.go
+++ b/server/router/judge.go
@@ -868,32 +868,6 @@ func JudgeStar(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
 }
 
-// POST /judge/break - Allows a judge to take a break and free up their current project
-func JudgeBreak(ctx *gin.Context) {
-	// Get the state from the context
-	state := GetState(ctx)
-
-	// Get the judge from the context
-	judge := ctx.MustGet("judge").(*models.Judge)
-
-	// Error if the judge doesn't have a current project
-	if judge.Current == nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "judge doesn't have a current project"})
-		return
-	}
-
-	// Basically skip the project for the judge
-	err := judging.SkipCurrentProject(state.Db, judge, state.Comps, "break", false)
-	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error skipping project: " + err.Error()})
-		return
-	}
-
-	// Send OK
-	state.Logger.JudgeLogf(judge, "Took a break from project %s", judge.Current.Hex())
-	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
-}
-
 type UpdateNotesRequest struct {
 	Notes string `json:"notes"`
 }


### PR DESCRIPTION
### Description

Remove "take a break" endpoint; this was already done in #226 for frontend but missed in backend (useless endpoint here).

### Fixes #273 

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)

### Is this a breaking change?

- [ ] Yes
- [X] No
