### PR TITLE
CASCADE deletes of projects/judges

### DIFF
--- a/client/src/components/admin/AdminToolbar.tsx
+++ b/client/src/components/admin/AdminToolbar.tsx
@@ -6,7 +6,7 @@ import { useAdminStore, useAdminTableStore, useOptionsStore } from '../../store'
 import ActionsDropdown from '../ActionsDropdown';
 import { postRequest } from '../../api';
 import { errorAlert } from '../../util';
-import MovePopup from './tables/MovePopup';
+import MoveGroupPopup from './tables/MoveGroupPopup';
 
 const AdminToolbar = (props: { showProjects: boolean; lastUpdate: Date }) => {
     const options = useOptionsStore((state) => state.options);
@@ -193,8 +193,8 @@ const AdminToolbar = (props: { showProjects: boolean; lastUpdate: Date }) => {
                 </p>
             </div>
             <FlagsPopup enabled={showFlags} setEnabled={setShowFlags} />
-            <MovePopup enabled={movePopup} setEnabled={setMovePopup} items={selectedIds} />
-            <MovePopup
+            <MoveGroupPopup enabled={movePopup} setEnabled={setMovePopup} items={selectedIds} />
+            <MoveGroupPopup
                 enabled={projectMovePopup}
                 setEnabled={setProjectMovePopup}
                 items={selectedIds}

--- a/client/src/components/admin/tables/JudgeRow.tsx
+++ b/client/src/components/admin/tables/JudgeRow.tsx
@@ -6,7 +6,7 @@ import { putRequest } from '../../../api';
 import { useAdminStore, useAdminTableStore, useOptionsStore } from '../../../store';
 import { twMerge } from 'tailwind-merge';
 import ActionsDropdown from '../../ActionsDropdown';
-import MovePopup from './MovePopup';
+import MoveGroupPopup from './MoveGroupPopup';
 import JudgeRanksPopup from './JudgeRanksPopup';
 
 interface JudgeRowProps {
@@ -123,7 +123,7 @@ const JudgeRow = ({ judge, idx }: JudgeRowProps) => {
                     </span>
                 </td>
             </tr>
-            <MovePopup enabled={movePopup} setEnabled={setMovePopup} item={judge} />
+            <MoveGroupPopup enabled={movePopup} setEnabled={setMovePopup} item={judge} />
             <DeletePopup enabled={deletePopup} setEnabled={setDeletePopup} element={judge} />
             <EditJudgePopup enabled={editPopup} setEnabled={setEditPopup} judge={judge} />
             <JudgeRanksPopup enabled={ranksPopup} setEnabled={setRanksPopup} judge={judge} />

--- a/client/src/components/admin/tables/MoveGroupPopup.tsx
+++ b/client/src/components/admin/tables/MoveGroupPopup.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import { postRequest, putRequest } from '../../../api';
+import ConfirmPopup from '../../ConfirmPopup';
+import { errorAlert } from '../../../util';
+import { useAdminStore, useAdminTableStore } from '../../../store';
+import TextInput from '../../TextInput';
+
+interface MoveGroupPopupProps {
+    /* State variable to open popup */
+    enabled: boolean;
+
+    /* Setter for open */
+    setEnabled: React.Dispatch<React.SetStateAction<boolean>>;
+
+    /* Set to true if operating on project(s) */
+    isProject?: boolean;
+
+    /* Item to move */
+    item?: Judge | Project;
+
+    /* List of item IDs (at least one of judge/judges should be defined) */
+    items?: string[];
+}
+
+const MoveGroupPopup = (props: MoveGroupPopupProps) => {
+    const [newGroup, setNewGroup] = useState('');
+    const fetchJudges = useAdminStore((state) => state.fetchJudges);
+    const fetchProjects = useAdminStore((state) => state.fetchProjects);
+    const setSelected = useAdminTableStore((state) => state.setSelected);
+    const selected = useAdminTableStore((state) => state.selected);
+
+    const handleSubmit = () => {
+        if (!props.item && !props.items) {
+            throw new Error('At least one of judge(s)/project(s) must be defined');
+        }
+
+        // Check to see if new group is valid
+        const group = Number(newGroup);
+        if (isNaN(group) || group < 0) {
+            alert('Invalid group number');
+            return;
+        }
+
+        if (props.item) {
+            moveGroup(group);
+        } else if (props.items) {
+            moveGroupMulti(group);
+        }
+    };
+
+    const moveGroup = async (group: number) => {
+        const res = await putRequest<OkResponse>(
+            `/${props.isProject ? 'project' : 'judge'}/move/group/${props.item?.id}`,
+            'admin',
+            {
+                group,
+            }
+        );
+        if (res.status !== 200) {
+            errorAlert(res);
+            return;
+        }
+
+        alert(`${props.isProject ? 'Project' : 'Judge'} moved to group ${group} successfully!`);
+        props.isProject ? fetchProjects() : fetchJudges();
+        props.setEnabled(false);
+    };
+
+    const moveGroupMulti = async (group: number) => {
+        const res = await postRequest<OkResponse>(
+            `/${props.isProject ? 'project' : 'judge'}/move/group`,
+            'admin',
+            {
+                items: props.items,
+                group,
+            }
+        );
+        if (res.status !== 200) {
+            errorAlert(res);
+            return;
+        }
+
+        alert(`Selected ${props.isProject ? 'projects' : 'judges'} moved to group ${group} successfully!`);
+        props.isProject ? fetchProjects() : fetchJudges();
+        props.setEnabled(false);
+        setSelected(new Array(selected.length).fill(false));
+    };
+
+    useEffect(() => {
+        if (!props.item) return;
+
+        setNewGroup(String(props.item.group));
+    }, [props.item]);
+
+    return (
+        <ConfirmPopup
+            enabled={props.enabled}
+            setEnabled={props.setEnabled}
+            onSubmit={handleSubmit}
+            submitText="Move"
+            title={`Move ${props.isProject ? 'Project' : 'Judge'} Group`}
+        >
+            <div className="flex flex-col items-center">
+                {props.item && (
+                    <p className="text-light">
+                        Move the {props.isProject ? 'project' : 'judge'}&nbsp;
+                        <span className="text-primary font-bold">{props.item?.name}</span> to
+                        another group. Enter the new group number below.
+                    </p>
+                )}
+                {props.items && (
+                    <p className="text-light">
+                        Move the selected {props.isProject ? 'projects' : 'judges'} to another
+                        group. Enter the new group number below.
+                    </p>
+                )}
+                <TextInput
+                    label="New group"
+                    text={newGroup}
+                    setText={setNewGroup}
+                    large
+                    className="mt-2"
+                />
+            </div>
+        </ConfirmPopup>
+    );
+};
+
+export default MoveGroupPopup;

--- a/client/src/components/admin/tables/ProjectRow.tsx
+++ b/client/src/components/admin/tables/ProjectRow.tsx
@@ -7,6 +7,7 @@ import { putRequest } from '../../../api';
 import FlagsPopup from '../FlagsPopup';
 import { twMerge } from 'tailwind-merge';
 import ActionsDropdown from '../../ActionsDropdown';
+import MoveGroupPopup from './MoveGroupPopup';
 import MovePopup from './MovePopup';
 
 interface ProjectRowProps {
@@ -21,6 +22,7 @@ const ProjectRow = ({ project, idx }: ProjectRowProps) => {
     const [flagPopupProjectId, setFlagPopupProjectId] = useState('');
     const [editPopup, setEditPopup] = useState(false);
     const [deletePopup, setDeletePopup] = useState(false);
+    const [moveGroupPopup, setMoveGroupPopup] = useState(false);
     const [movePopup, setMovePopup] = useState(false);
     const fetchProjects = useAdminStore((state) => state.fetchProjects);
     const options = useOptionsStore((state) => state.options);
@@ -147,6 +149,7 @@ const ProjectRow = ({ project, idx }: ProjectRowProps) => {
                             'Edit',
                             project.active ? 'Hide' : 'Unhide',
                             project.prioritized ? 'Unprioritize' : 'Prioritize',
+                            'Move Table',
                             'Move Groups',
                             'Delete',
                         ]}
@@ -155,9 +158,10 @@ const ProjectRow = ({ project, idx }: ProjectRowProps) => {
                             hideProject,
                             prioritizeProject,
                             setMovePopup.bind(null, true),
+                            setMoveGroupPopup.bind(null, true),
                             setDeletePopup.bind(null, true),
                         ]}
-                        redIndices={[4]}
+                        redIndices={[5]}
                     />
                     <div
                         className="cursor-pointer hover:text-primary duration-150 mr-2"
@@ -176,7 +180,8 @@ const ProjectRow = ({ project, idx }: ProjectRowProps) => {
             />
             <DeletePopup enabled={deletePopup} setEnabled={setDeletePopup} element={project} />
             <EditProjectPopup enabled={editPopup} setEnabled={setEditPopup} project={project} />
-            <MovePopup enabled={movePopup} setEnabled={setMovePopup} item={project} isProject />
+            <MovePopup enabled={movePopup} setEnabled={setMovePopup} item={project} />
+            <MoveGroupPopup enabled={moveGroupPopup} setEnabled={setMoveGroupPopup} item={project} isProject />
         </>
     );
 };

--- a/server/database/flag.go
+++ b/server/database/flag.go
@@ -79,3 +79,18 @@ func DeleteFlag(db *mongo.Database, ctx context.Context, flagId *primitive.Objec
 	_, err := db.Collection("flags").DeleteOne(ctx, gin.H{"_id": flagId})
 	return err
 }
+
+// DeleteFlagsCascade will delete flags based on either the project ID and/or judge ID
+// This is used in a cascade deletion when projects/judges are deleted
+func DeleteFlagsCascade(db *mongo.Database, ctx context.Context, projectId *primitive.ObjectID, judgeId *primitive.ObjectID) error {
+	filter := make(gin.H)
+	if projectId != nil {
+		filter["project_id"] = projectId
+	}
+	if judgeId != nil {
+		filter["judge_id"] = judgeId
+	}
+
+	_, err := db.Collection("flags").DeleteMany(ctx, filter)
+	return err
+}

--- a/server/database/judge.go
+++ b/server/database/judge.go
@@ -419,3 +419,16 @@ func SetJudgesGroup(db *mongo.Database, ctx context.Context, judgeIds []primitiv
 	_, err := db.Collection("judges").UpdateMany(ctx, gin.H{"_id": gin.H{"$in": judgeIds}}, gin.H{"$set": gin.H{"group": group, "group_seen": 0}})
 	return err
 }
+
+// UpdateSeenProjectNumber will change the table number for all instances of a seen project
+func UpdateSeenProjectNumber(db *mongo.Database, ctx context.Context, projectId *primitive.ObjectID, newLocation int64) error {
+	_, err := db.Collection("judges").UpdateMany(
+		ctx,
+		gin.H{"seen_projects.project_id": projectId},
+		gin.H{"$set": gin.H{"seen_projects.$[elem].location": newLocation}},
+		options.Update().SetArrayFilters(options.ArrayFilters{
+			Filters: []any{gin.H{"elem.project_id": projectId}},
+		}),
+	)
+	return err
+}

--- a/server/judging/judging_flow.go
+++ b/server/judging/judging_flow.go
@@ -24,7 +24,7 @@ func SkipCurrentProject(db *mongo.Database, judge *models.Judge, comps *Comparis
 // This should be run in a transaction.
 func SkipCurrentProjectWithTx(db *mongo.Database, ctx context.Context, judge *models.Judge, comps *Comparisons, reason string, getNew bool) error {
 	// Get skipped project from database
-	skippedProject, err := database.FindProjectById(db, ctx, judge.Current)
+	skippedProject, err := database.FindProject(db, ctx, judge.Current)
 	if err != nil {
 		return errors.New("error finding skipped project in database: " + err.Error())
 	}

--- a/server/router/init.go
+++ b/server/router/init.go
@@ -138,11 +138,12 @@ func NewRouter(db *mongo.Database, logger *logging.Logger) *gin.Engine {
 	adminRouter.POST("/project/prioritize", PrioritizeSelectedProjects)
 	adminRouter.POST("/project/hide", HideSelectedProjects)
 	adminRouter.POST("/judge/hide", HideSelectedJudges)
-	adminRouter.POST("/judge/move", MoveSelectedJudges)
+	adminRouter.PUT("/judge/move/group/:id", MoveJudge)
+	adminRouter.POST("/judge/move/group", MoveSelectedJudges)
 	adminRouter.DELETE("/admin/flag/:id", RemoveFlag)
-	adminRouter.PUT("/judge/move/:id", MoveJudge)
 	adminRouter.PUT("/project/move/:id", MoveProject)
-	adminRouter.POST("/project/move", MoveSelectedProjects)
+	adminRouter.PUT("/project/move/group/:id", MoveProjectGroup)
+	adminRouter.POST("/project/move/group", MoveSelectedProjectsGroup)
 	adminRouter.POST("/admin/deliberation", SetDeliberation)
 
 	// Admin panel - log

--- a/server/router/judge.go
+++ b/server/router/judge.go
@@ -343,10 +343,39 @@ func DeleteJudge(ctx *gin.Context) {
 		return
 	}
 
-	// Delete judge from database
-	err = database.DeleteJudgeById(state.Db, judgeObjectId)
+	// Run in transaction
+	err = database.WithTransaction(state.Db, func(sc mongo.SessionContext) error {
+		// Get judge data
+		judge, err := database.FindJudge(state.Db, sc, judgeObjectId)
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "could not get judge: " + err.Error()})
+			return err
+		}
+
+		// Delete judge from database
+		err = database.DeleteJudgeById(state.Db, sc, judgeObjectId)
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error deleting judge from database: " + err.Error()})
+			return err
+		}
+
+		// Decrement the seen number of all projects in the judge's seen_projects array
+		err = database.DecrementDeletedJudgeSeen(state.Db, sc, judge)
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "could not decrement seen for judged projects: " + err.Error()})
+			return err
+		}
+
+		// Delete all flags for judge
+		err = database.DeleteFlagsCascade(state.Db, sc, nil, &judgeObjectId)
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error deleting flags for judge: " + err.Error()})
+			return err
+		}
+
+		return nil
+	})
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error deleting judge from database: " + err.Error()})
 		return
 	}
 
@@ -458,7 +487,7 @@ func GetJudgedProject(ctx *gin.Context) {
 	for _, p := range judge.SeenProjects {
 		if p.ProjectId.Hex() == projectId {
 			// Add URL to judged project
-			proj, err := database.FindProjectById(state.Db, ctx, &p.ProjectId)
+			proj, err := database.FindProject(state.Db, ctx, &p.ProjectId)
 			if err != nil {
 				ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error getting project url: " + err.Error()})
 				return
@@ -669,7 +698,7 @@ func JudgeFinish(ctx *gin.Context) {
 		}
 
 		// Get the project from the database
-		project, err := database.FindProjectById(state.Db, sc, judge.Current)
+		project, err := database.FindProject(state.Db, sc, judge.Current)
 		if err != nil {
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error finding project in database: " + err.Error()})
 			return err

--- a/server/router/judge.go
+++ b/server/router/judge.go
@@ -938,7 +938,7 @@ func MoveJudge(ctx *gin.Context) {
 	id := ctx.Param("id")
 
 	// Get the request object
-	var moveReq util.MoveRequest
+	var moveReq util.MoveGroupRequest
 	err := ctx.BindJSON(&moveReq)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "error reading request body: " + err.Error()})

--- a/server/router/project.go
+++ b/server/router/project.go
@@ -621,8 +621,8 @@ func GetChallenges(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, challenges)
 }
 
-// PUT /project/move/:id - Move a project to a different group
-func MoveProject(ctx *gin.Context) {
+// PUT /project/move/group/:id - Move a project to a different group
+func MoveProjectGroup(ctx *gin.Context) {
 	// Get the state from the context
 	state := GetState(ctx)
 
@@ -635,7 +635,7 @@ func MoveProject(ctx *gin.Context) {
 	}
 
 	// Get the request object
-	var moveReq util.MoveRequest
+	var moveReq util.MoveGroupRequest
 	err = ctx.BindJSON(&moveReq)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "error reading request body: " + err.Error()})
@@ -684,9 +684,16 @@ func MoveProject(ctx *gin.Context) {
 		}
 
 		// Move the project to the new group
-		err = database.SetProjectNum(state.Db, sc, id, currMaxNum+1, moveReq.Group)
+		err = database.SetProjectNum(state.Db, sc, id, currMaxNum+1, &moveReq.Group)
 		if err != nil {
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error moving project group: " + err.Error()})
+			return err
+		}
+
+		// Update judge seen_projects' location
+		err = database.UpdateSeenProjectNumber(state.Db, sc, &id, currMaxNum+1)
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "cannot update judges' seen projects: " + err.Error()})
 			return err
 		}
 
@@ -701,8 +708,63 @@ func MoveProject(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
 }
 
+// PUT /project/move/:id - Move a project to a different table number
+func MoveProject(ctx *gin.Context) {
+	// Get the state from the context
+	state := GetState(ctx)
+
+	// Get the ID from the URL
+	rawId := ctx.Param("id")
+	id, err := primitive.ObjectIDFromHex(rawId)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid project ID"})
+		return
+	}
+
+	// Get the request object
+	var moveReq util.MoveRequest
+	err = ctx.BindJSON(&moveReq)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "error reading request body: " + err.Error()})
+		return
+	}
+
+	// Run the remaining actions in a transaction
+	err = database.WithTransaction(state.Db, func(sc mongo.SessionContext) error {
+		// Check if there's another project in the new location
+		clash, err := database.FindProjectByLocation(state.Db, sc, moveReq.Location)
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error in finding project at new location: " + err.Error()})
+			return err
+		}
+		if clash != nil {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": "there is already another project in that location"})
+			return err
+		}
+
+		// Move the project!
+		err = database.SetProjectNum(state.Db, sc, id, moveReq.Location, nil)
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "cannot set project num: " + err.Error()})
+			return err
+		}
+
+		// Update judge seen_projects' location
+		err = database.UpdateSeenProjectNumber(state.Db, sc, &id, moveReq.Location)
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "cannot update judges' seen projects: " + err.Error()})
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return
+	}
+}
+
 // POST /project/move - Move selected projects to a different group
-func MoveSelectedProjects(ctx *gin.Context) {
+func MoveSelectedProjectsGroup(ctx *gin.Context) {
 	// Get the state from the context
 	state := GetState(ctx)
 

--- a/server/util/structs.go
+++ b/server/util/structs.go
@@ -22,8 +22,12 @@ type PrioritizeSelectedRequest struct {
 	Prioritize bool                 `json:"prioritize"`
 }
 
-type MoveRequest struct {
+type MoveGroupRequest struct {
 	Group int64 `json:"group"`
+}
+
+type MoveRequest struct {
+	Location int64 `json:"location"`
 }
 
 type MoveSelectedRequest struct {


### PR DESCRIPTION
### Description

- Database foreign key constraints:
  - Delete project = delete project from judge seen + rankings
  - Delete project = delete flags with project
  - Delete judge = delete flags with judge
  - Delete judge = decrement project seen count
- Also updated seen_project when moving table number or project group
- Added the ability to move projects to a specific table number

### Fixes #230 

### Fixes #260 

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Is this a breaking change?

- [ ] Yes
- [X] No
