### PR TITLE
Views per project can be specified per track

### DIFF
--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -124,6 +124,7 @@ interface Options {
     clock_sync: boolean;
     judge_tracks: boolean;
     tracks: string[];
+    track_views: number[];
     multi_group: boolean;
     num_groups: number;
     group_sizes: number[];

--- a/server/database/options.go
+++ b/server/database/options.go
@@ -36,11 +36,17 @@ func UpdateOptions(db *mongo.Database, ctx context.Context, options *models.Opti
 	if options.ClockSync != nil {
 		update["clock_sync"] = *options.ClockSync
 	}
+	if options.Deliberation != nil {
+		update["deliberation"] = *options.Deliberation
+	}
 	if options.JudgeTracks != nil {
 		update["judge_tracks"] = *options.JudgeTracks
 	}
 	if options.Tracks != nil {
 		update["tracks"] = *options.Tracks
+	}
+	if options.TrackViews != nil {
+		update["track_views"] = *options.TrackViews
 	}
 	if options.MultiGroup != nil {
 		update["multi_group"] = *options.MultiGroup

--- a/server/models/options.go
+++ b/server/models/options.go
@@ -11,8 +11,9 @@ type Options struct {
 	ClockSync      bool               `bson:"clock_sync" json:"clock_sync"`
 	Deliberation   bool               `bson:"deliberation" json:"deliberation"`
 	JudgeTracks    bool               `bson:"judge_tracks" json:"judge_tracks"`
-	Tracks         []string           `bson:"tracks" json:"tracks"`
 	MultiGroup     bool               `bson:"multi_group" json:"multi_group"`
+	Tracks         []string           `bson:"tracks" json:"tracks"`                     // Names of each track
+	TrackViews     []int64            `bson:"track_views" json:"track_views"`           // Number of views per track (same len as tracks)
 	NumGroups      int64              `bson:"num_groups" json:"num_groups"`             // Number of groups to split projects into
 	GroupSizes     []int64            `bson:"group_sizes" json:"group_sizes"`           // Number of projects in each group except last (last group will be remainder, size = numGroups - 1)
 	SwitchingMode  string             `bson:"switching_mode" json:"switching_mode"`     // "auto" or "manual"
@@ -36,6 +37,7 @@ func NewOptions() *Options {
 		Deliberation:   false,
 		JudgeTracks:    false,
 		Tracks:         []string{},
+		TrackViews:     []int64{},
 		MultiGroup:     false,
 		NumGroups:      3,
 		GroupSizes:     []int64{30, 30, 30},
@@ -55,8 +57,10 @@ type OptionalOptions struct {
 	JudgingTimer   *int64    `bson:"judging_timer,omitempty" json:"judging_timer,omitempty"`
 	MinViews       *int64    `bson:"min_views,omitempty" json:"min_views,omitempty"`
 	ClockSync      *bool     `bson:"clock_sync,omitempty" json:"clock_sync,omitempty"`
+	Deliberation   *bool     `bson:"deliberation" json:"deliberation"`
 	JudgeTracks    *bool     `bson:"judge_tracks,omitempty" json:"judge_tracks,omitempty"`
 	Tracks         *[]string `bson:"tracks,omitempty" json:"tracks,omitempty"`
+	TrackViews     *[]int64  `bson:"track_views,omitempty" json:"track_views,omitempty"`
 	MultiGroup     *bool     `bson:"multi_group,omitempty" json:"multi_group,omitempty"`
 	NumGroups      *int64    `bson:"num_groups,omitempty" json:"num_groups,omitempty"`
 	GroupSizes     *[]int64  `bson:"group_sizes,omitempty" json:"group_sizes,omitempty"`

--- a/server/router/admin.go
+++ b/server/router/admin.go
@@ -652,7 +652,7 @@ func SetDeliberation(ctx *gin.Context) {
 	}
 
 	// Update the deliberation state
-	err = database.UpdateDeliberation(state.Db, ctx, req.Start)
+	err = database.UpdateOptions(state.Db, ctx, &models.OptionalOptions{Deliberation: &req.Start})
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error updating deliberation: " + err.Error()})
 		return
@@ -748,5 +748,104 @@ func SetMaxReqs(ctx *gin.Context) {
 
 	// Send OK
 	state.Logger.AdminLogf("Updated max requests to %d", *req.MaxReqPerMin)
+	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+}
+
+// POST /admin/tracks - updates the tracks to judge
+func SetTracks(ctx *gin.Context) {
+	// Get the state from the context
+	state := GetState(ctx)
+
+	// Get the options
+	options, err := database.GetOptions(state.Db, ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "could not get settings: " + err.Error()})
+		return
+	}
+
+	// Get the request
+	var req models.OptionalOptions
+	err = ctx.BindJSON(&req)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "error parsing request: " + err.Error()})
+		return
+	}
+
+	// Make sure the tracks field is valid
+	if req.Tracks == nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid tracks field"})
+		return
+	}
+
+	// Make sure track views are equal length. If not, cut or add
+	diff := len(*req.Tracks) - len(options.TrackViews)
+	changeViews := true
+	if diff > 0 { // More tracks = add to views
+		for range diff {
+			options.TrackViews = append(options.TrackViews, 3) // Default track views = 3
+		}
+	} else if diff < 0 { // Less tracks = remove from views
+		options.TrackViews = options.TrackViews[:len(options.TrackViews)+diff]
+	} else {
+		changeViews = false
+	}
+
+	// Update options
+	update := models.OptionalOptions{Tracks: req.Tracks}
+	if changeViews {
+		update.TrackViews = &options.TrackViews
+	}
+	err = database.UpdateOptions(state.Db, ctx, &update)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error updating tracks: " + err.Error()})
+		return
+	}
+
+	// Send OK
+	state.Logger.AdminLogf("Updated tracks to %s", util.StructToStringWithoutNils(req))
+	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
+}
+
+// POST /admin/track-views - updates the number of views per track
+func SetTrackViews(ctx *gin.Context) {
+	// Get the state from the context
+	state := GetState(ctx)
+
+	// Get the options
+	options, err := database.GetOptions(state.Db, ctx)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "could not get settings: " + err.Error()})
+		return
+	}
+
+	// Get the request
+	var req models.OptionalOptions
+	err = ctx.BindJSON(&req)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "error parsing request: " + err.Error()})
+		return
+	}
+
+	// Make sure the track views field is valid
+	if req.TrackViews == nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid track views field"})
+		return
+	}
+
+	// Make sure the track views field is the same length as the tracks
+	if len(options.Tracks) != len(*req.TrackViews) {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "track views must be the same length as tracks"})
+		return
+	}
+
+	// Update the options
+	err = database.UpdateOptions(state.Db, ctx, &models.OptionalOptions{TrackViews: req.TrackViews})
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "error updating track views: " + err.Error()})
+		return
+	}
+
+	// Send OK
+	state.Logger.AdminLogf("Updated track views to %s", util.StructToStringWithoutNils(req))
 	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
 }

--- a/server/router/init.go
+++ b/server/router/init.go
@@ -120,6 +120,8 @@ func NewRouter(db *mongo.Database, logger *logging.Logger) *gin.Engine {
 	judgeRouter.GET("/admin/timer", GetJudgingTimer)
 	adminRouter.GET("/admin/options", GetOptions)
 	adminRouter.POST("/admin/options", SetOptions)
+	adminRouter.POST("/admin/tracks", SetTracks)
+	adminRouter.POST("/admin/track-views", SetTrackViews)
 	adminRouter.POST("/admin/num-groups", SetNumGroups)
 	adminRouter.POST("/admin/group-sizes", SetGroupSizes)
 	adminRouter.POST("/admin/block-reqs", SetBlockReqs)


### PR DESCRIPTION
### Description

- Add `track_views` options
- Add settings to specify views/project for each track
- Split tracks into its own settings section

### Fixes #243 

### Type of Change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Is this a breaking change?

- [X] Yes
- [ ] No
