### PR TITLE
Added fine-grained reset

### DIFF
--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -190,3 +190,9 @@ interface CSVFormState {
     setNoSend: React.Dispatch<React.SetStateAction<boolean>>;
     format: 'project' | 'judge' | 'devpost';
 }
+
+interface ResetPopup {
+    open: boolean;
+    text: string;
+    handler: null | (() => void);
+}


### PR DESCRIPTION
### Description

Add buttons to reset parts of the database, such as judging status and projects/judges only.

### Fixes #177 

### Type of Change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Is this a breaking change?

- [ ] Yes
- [X] No
