### PR TITLE
Track flagged projects for judge seen count

### DIFF
--- a/client/src/pages/judge/index.tsx
+++ b/client/src/pages/judge/index.tsx
@@ -99,7 +99,7 @@ const Judge = () => {
                     </Button>
                 </div>
                 <div className="flex justify-evenly">
-                    <StatBlock name="Seen" value={judge.seen_projects.length as number} />
+                    <StatBlock name="Seen" value={judge.seen_projects.length + judge.flagged.length} />
                     <StatBlock name="Total Projects" value={projCount} />
                 </div>
                 {judge.track === '' ? (

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -44,6 +44,7 @@ interface Judge {
     active: boolean;
     group: number;
     current: string;
+    flagged: string[];
     last_activity: number;
 }
 

--- a/server/database/admin.go
+++ b/server/database/admin.go
@@ -143,6 +143,7 @@ func DropJudgingData(db *mongo.Database) error {
 			"seen_projects": []models.JudgedProject{},
 			"rankings":      []primitive.ObjectID{},
 			"rankings_agg":  []models.AggRanking{},
+			"flagged":       []primitive.ObjectID{},
 		}},
 	)
 	if err != nil {

--- a/server/judging/judging_flow.go
+++ b/server/judging/judging_flow.go
@@ -29,32 +29,38 @@ func SkipCurrentProjectWithTx(db *mongo.Database, ctx context.Context, judge *mo
 		return errors.New("error finding skipped project in database: " + err.Error())
 	}
 
-	// If skipping for any reason other than wanting a break, add the project to the skipped list
-	if reason != "break" {
-		// Create a new skip object
-		skip, err := models.NewFlag(skippedProject, judge, reason)
-		if err != nil {
-			return errors.New("error creating flag object: " + err.Error())
-		}
+	// Create a new skip object
+	skip, err := models.NewFlag(skippedProject, judge, reason)
+	if err != nil {
+		return errors.New("error creating flag object: " + err.Error())
+	}
 
-		// Add skipped project to flags database
-		err = database.InsertFlag(db, ctx, skip)
-		if err != nil {
-			return errors.New("error inserting flag into database: " + err.Error())
-		}
+	// Add skipped project to flags database
+	err = database.InsertFlag(db, ctx, skip)
+	if err != nil {
+		return errors.New("error inserting flag into database: " + err.Error())
+	}
+
+	// Add to flagged project if reason is not busy or absent
+	push := make(gin.H)
+	if reason != "busy" && reason != "absent" {
+		push["flagged"] = skippedProject.Id
 	}
 
 	// Update the judge
 	_, err = db.Collection("judges").UpdateOne(
 		ctx,
 		gin.H{"_id": judge.Id},
-		gin.H{"$set": gin.H{"current": nil, "last_activity": util.Now()}},
+		gin.H{
+			"$set":  gin.H{"current": nil, "last_activity": util.Now()},
+			"$push": push,
+		},
 	)
 	if err != nil {
 		return err
 	}
 
-	// Hide the project if it has been skipped more than 3 times
+	// Hide the project if it has been skipped for absent more than 3 times
 	err = HideAbsentProject(db, ctx, skippedProject)
 	if err != nil {
 		return errors.New("error hiding absent project: " + err.Error())

--- a/server/judging/judging_flow.go
+++ b/server/judging/judging_flow.go
@@ -254,10 +254,13 @@ func FindAvailableItems(db *mongo.Database, ctx context.Context, judge *models.J
 		return nil, err
 	}
 
-	// Create a set of voted projects and skipped projects
+	// Create a set of voted, skipped, and flagged projects
 	done := make(map[string]bool)
 	for _, proj := range judge.SeenProjects {
 		done[proj.ProjectId.Hex()] = true
+	}
+	for _, f := range judge.Flagged {
+		done[f.Hex()] = true
 	}
 	for _, flag := range flags {
 		done[flag.ProjectId.Hex()] = true

--- a/server/models/judge.go
+++ b/server/models/judge.go
@@ -26,6 +26,7 @@ type Judge struct {
 	SeenProjects []JudgedProject      `bson:"seen_projects" json:"seen_projects"`
 	Rankings     []primitive.ObjectID `bson:"rankings" json:"rankings"`
 	RankingsAgg  []AggRanking         `bson:"rankings_agg" json:"rankings_agg"` // Aggregation for ranking scoring
+	Flagged      []primitive.ObjectID `bson:"flagged" json:"flagged"`           // Projects that the judge has flagged (not ranked)
 	LastActivity primitive.DateTime   `bson:"last_activity" json:"last_activity"`
 }
 
@@ -61,6 +62,7 @@ func NewJudge(name string, email string, track string, notes string, group int64
 		SeenProjects: []JudgedProject{},
 		Rankings:     []primitive.ObjectID{},
 		RankingsAgg:  []AggRanking{},
+		Flagged:      []primitive.ObjectID{},
 		LastActivity: primitive.DateTime(0),
 	}
 }


### PR DESCRIPTION
### Description

- Add a field to judges to track the projects they've flagged
- This will allow them to see an accurate count of projects they've viewed
- It also prevents them from being assigned a project that they've previously flagged.

### Fixes #142 

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Is this a breaking change?

- [X] Yes
- [ ] No
