### PR TITLE
Minor UX fixes

### DIFF
--- a/client/src/components/admin/ActionsPopup.tsx
+++ b/client/src/components/admin/ActionsPopup.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { postRequest } from '../../api';
-import { useAdminStore, useClockStore, useOptionsStore } from '../../store';
+import { useAdminStore, useOptionsStore } from '../../store';
 import { errorAlert } from '../../util';
 import Button from '../Button';
 import ConfirmPopup from '../ConfirmPopup';
@@ -17,7 +17,9 @@ interface ActionsPopupProps {
 }
 
 const ActionsItem = ({ children }: { children: React.ReactNode }) => {
-    return <div className="flex flex-col md:flex-row mb-4 md:mb-0 items-center gap-3">{children}</div>;
+    return (
+        <div className="flex flex-col md:flex-row mb-4 md:mb-0 items-center gap-3">{children}</div>
+    );
 };
 
 const ActionsPopup = (props: ActionsPopupProps) => {
@@ -25,7 +27,6 @@ const ActionsPopup = (props: ActionsPopupProps) => {
     const options = useOptionsStore((state) => state.options);
     const fetchOptions = useOptionsStore((state) => state.fetchOptions);
     const fetchJudges = useAdminStore((state) => state.fetchJudges);
-    const clock = useClockStore((state) => state.clock);
     const [deliberationPopup, setDeliberationPopup] = useState(false);
     const [swapPopup, setSwapPopup] = useState(false);
 
@@ -85,7 +86,6 @@ const ActionsPopup = (props: ActionsPopupProps) => {
                                 <Button
                                     type="gold"
                                     onClick={setSwapPopup.bind(null, true)}
-                                    disabled={clock.running}
                                     tooltip="Groups can only be swapped when judging is paused"
                                     bold
                                     className="py-2"
@@ -99,7 +99,7 @@ const ActionsPopup = (props: ActionsPopupProps) => {
                             </div>
 
                             <Paragraph
-                                text="Prevent judges from making changes to ranking and stars."
+                                text="Manually swap judge groups, sending every judge to the next group."
                                 className="basis-1/2 grow-0 shrink-0"
                             />
                         </ActionsItem>

--- a/client/src/components/admin/ActionsPopup.tsx
+++ b/client/src/components/admin/ActionsPopup.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { postRequest } from '../../api';
-import { useAdminStore, useOptionsStore } from '../../store';
+import { useAdminStore, useClockStore, useOptionsStore } from '../../store';
 import { errorAlert } from '../../util';
 import Button from '../Button';
 import ConfirmPopup from '../ConfirmPopup';
@@ -27,6 +27,7 @@ const ActionsPopup = (props: ActionsPopupProps) => {
     const options = useOptionsStore((state) => state.options);
     const fetchOptions = useOptionsStore((state) => state.fetchOptions);
     const fetchJudges = useAdminStore((state) => state.fetchJudges);
+    const fetchClock = useClockStore((state) => state.fetchClock);
     const [deliberationPopup, setDeliberationPopup] = useState(false);
     const [swapPopup, setSwapPopup] = useState(false);
 
@@ -59,6 +60,9 @@ const ActionsPopup = (props: ActionsPopupProps) => {
                 'Deliberation has started! Judges will no longer be able to edit their rankings.'
             );
         }
+
+        fetchClock();
+        setDeliberationPopup(false);
     };
 
     return (
@@ -67,14 +71,16 @@ const ActionsPopup = (props: ActionsPopupProps) => {
                 <h1 className="text-5xl text-center font-bold mb-6">Actions</h1>
                 <div className="flex flex-col w-full gap-3">
                     <ActionsItem>
-                        <Button
-                            type="primary"
-                            onClick={() => navigate('/admin/log')}
-                            bold
-                            className="py-2 basis-1/2 grow-0 shrink-0"
-                        >
-                            Audit Log
-                        </Button>
+                        <div className="basis-1/2 grow-0 shrink-0 flex items-center justify-center">
+                            <Button
+                                type="primary"
+                                onClick={() => navigate('/admin/log')}
+                                bold
+                                className="py-2"
+                            >
+                                Audit Log
+                            </Button>
+                        </div>
                         <Paragraph
                             text="View all changes that have happened in Jury."
                             className="basis-1/2 grow-0 shrink-0"
@@ -105,15 +111,17 @@ const ActionsPopup = (props: ActionsPopupProps) => {
                         </ActionsItem>
                     )}
                     <ActionsItem>
-                        <Button
-                            type={options.deliberation ? 'outline' : 'error'}
-                            onClick={setDeliberationPopup.bind(null, true)}
-                            bold
-                            tooltip="Stop judges from editing their rankings during deliberation"
-                            className="py-2 basis-1/2 grow-0 shrink-0"
-                        >
-                            {options.deliberation ? 'End Deliberation' : 'Start Deliberation'}
-                        </Button>
+                        <div className="basis-1/2 grow-0 shrink-0 flex items-center justify-center">
+                            <Button
+                                type={options.deliberation ? 'outline' : 'error'}
+                                onClick={setDeliberationPopup.bind(null, true)}
+                                bold
+                                tooltip="Stop judges from editing their rankings during deliberation"
+                                className="py-2"
+                            >
+                                {options.deliberation ? 'End Deliberation' : 'Start Deliberation'}
+                            </Button>
+                        </div>
                         <Paragraph
                             text="Prevent judges from making changes to ranking and stars."
                             className="basis-1/2 grow-0 shrink-0"

--- a/client/src/components/admin/CSVPreview.tsx
+++ b/client/src/components/admin/CSVPreview.tsx
@@ -27,7 +27,7 @@ const CSVPreview = (props: CSVPreviewProps) => {
     return (
         <div className="w-full flex flex-col p-2 border-lightest border-2 rounded-md">
             <h2 className="text-center text-2xl font-bold text-light">CSV Preview</h2>
-            <div className="w-full overflow-x-auto">
+            <div className="w-full overflow-x-auto max-h-[500px]">
                 <table className="table-fixed w-full text-lg">
                     <tbody>
                         {csvData.map((row, index) => (

--- a/client/src/components/admin/UploadCSVForm.tsx
+++ b/client/src/components/admin/UploadCSVForm.tsx
@@ -147,7 +147,7 @@ const UploadCSVForm = (props: UploadCSVFormProps) => {
                             </label>
                         </div>
                         {file && (
-                            <div className="flex w-full h-11 px-4 text-2xl border-2 border-lightest rounded-md text-start items-center">
+                            <div className="flex w-full px-4 py-2 md:text-xl text-md border-2 border-lightest rounded-md text-start items-center">
                                 File Chosen: {fileName}
                             </div>
                         )}

--- a/client/src/components/admin/tables/JudgeRow.tsx
+++ b/client/src/components/admin/tables/JudgeRow.tsx
@@ -111,7 +111,7 @@ const JudgeRow = ({ judge, idx }: JudgeRowProps) => {
                             setMovePopup.bind(null, true),
                             setDeletePopup.bind(null, true),
                         ]}
-                        redIndices={[3]}
+                        redIndices={[4]}
                     />
                     <span
                         className="cursor-pointer px-1 hover:text-primary duration-150"

--- a/client/src/components/admin/tables/ProjectRow.tsx
+++ b/client/src/components/admin/tables/ProjectRow.tsx
@@ -150,7 +150,7 @@ const ProjectRow = ({ project, idx }: ProjectRowProps) => {
                             project.active ? 'Hide' : 'Unhide',
                             project.prioritized ? 'Unprioritize' : 'Prioritize',
                             'Move Table',
-                            'Move Groups',
+                            'Move Group',
                             'Delete',
                         ]}
                         actionFunctions={[

--- a/client/src/pages/Expo.tsx
+++ b/client/src/pages/Expo.tsx
@@ -14,7 +14,7 @@ const Expo = () => {
     const [nameSort, setNameSort] = useState(false);
     const [track, setTrack] = useState('');
     const [challenges, setChallenges] = useState<string[]>([]);
-    const [groupNames, setGroupNames] = useState<string[]>([]);
+    const [groupInfo, setGroupInfo] = useState<GroupInfo>({ enabled: false, names: [] });
     const [searchParams, _] = useSearchParams();
     const navigate = useNavigate();
 
@@ -36,12 +36,13 @@ const Expo = () => {
                 return;
             }
 
-            const groupRes = await getRequest<string[]>('/group-names', '');
+            const groupRes = await getRequest<GroupInfo>('/group-info', '');
             if (groupRes.status !== 200) {
                 errorAlert(groupRes);
                 return;
             }
-            setGroupNames(groupRes.data as string[]);
+            const gi = groupRes.data as GroupInfo;
+            setGroupInfo({ enabled: gi.enabled && gi.names.length > 0, names: gi.names });
 
             setChallenges(['', ...(res.data as string[])]);
         }
@@ -86,7 +87,7 @@ const Expo = () => {
                 <table className="table-fixed">
                     <thead className="text-left">
                         <tr>
-                            <th className="pr-2">Group</th>
+                            {groupInfo.enabled && <th className="pr-2">Group</th>}
                             <th className="pr-2">Table</th>
                             <th className="pr-2">Name</th>
                         </tr>
@@ -94,7 +95,9 @@ const Expo = () => {
                     <tbody>
                         {projects.map((project, idx) => (
                             <tr key={idx}>
-                                <td className="pr-2">{groupNames[project.group]}</td>
+                                {groupInfo.enabled && (
+                                    <td className="pr-2">{groupInfo.names[project.group]}</td>
+                                )}
                                 <td className="pr-2">{project.location}</td>
                                 <td className="pr-2">{project.name}</td>
                             </tr>
@@ -128,7 +131,7 @@ const Expo = () => {
                         navigate('/expo/' + t.replace(/\s/g, '%20'));
                     }}
                     options={challenges ?? []}
-                    className="my-2"
+                    className="my-2 md:mx-0 mx-4"
                 />
                 <h3 className="text-center font-bold text-lighter text-2xl">
                     Count: {projects.length}
@@ -142,8 +145,8 @@ const Expo = () => {
                         Print this page
                     </Button>
                 </div>
-                <table className="mb-4">
-                    <thead>
+                <table className="mb-4 table-fixed w-full">
+                    <thead className="w-full">
                         <tr>
                             <th
                                 onClick={() => setNameSort(true)}
@@ -157,12 +160,13 @@ const Expo = () => {
                             <th
                                 onClick={() => setNameSort(false)}
                                 className={
-                                    'px-4 py-2 cursor-pointer text-left ' +
+                                    'px-4 py-2 cursor-pointer text-left w-12 ' +
                                     (!nameSort && 'underline')
                                 }
                             >
                                 Table
                             </th>
+                            {groupInfo.enabled && <th className="px-4 py-2 text-left w-32">Group</th>}
                         </tr>
                     </thead>
                     <tbody>
@@ -179,6 +183,9 @@ const Expo = () => {
                                     </a>
                                 </td>
                                 <td className="px-4 py-2">{project.location}</td>
+                                {groupInfo.enabled && (
+                                    <td className="px-4 py-2">{groupInfo.names[project.group]}</td>
+                                )}
                             </tr>
                         ))}
                     </tbody>

--- a/client/src/types.d.ts
+++ b/client/src/types.d.ts
@@ -197,3 +197,8 @@ interface ResetPopup {
     text: string;
     handler: null | (() => void);
 }
+
+interface GroupInfo {
+    names: string[];
+    enabled: boolean;
+}

--- a/server/router/admin.go
+++ b/server/router/admin.go
@@ -695,6 +695,13 @@ func SetDeliberation(ctx *gin.Context) {
 		return
 	}
 
+	// Also pause judging if deliberation has started
+	if req.Start {
+		state.Clock.Mutex.Lock()
+		state.Clock.State.Pause()
+		state.Clock.Mutex.Unlock()
+	}
+
 	// Send OK
 	hap := "Started"
 	if !req.Start {

--- a/server/router/admin.go
+++ b/server/router/admin.go
@@ -704,8 +704,8 @@ func SetDeliberation(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{"ok": 1})
 }
 
-// GET /group-names - GetGroupNames returns the names of the groups
-func GetGroupNames(ctx *gin.Context) {
+// GET /group-info - GetGroupInfo returns the names of the groups and if groups are enabled
+func GetGroupInfo(ctx *gin.Context) {
 	// Get the state from the context
 	state := GetState(ctx)
 
@@ -717,7 +717,10 @@ func GetGroupNames(ctx *gin.Context) {
 	}
 
 	// Send OK
-	ctx.JSON(http.StatusOK, options.GroupNames)
+	ctx.JSON(http.StatusOK, gin.H{
+		"names":   options.GroupNames,
+		"enabled": options.MultiGroup,
+	})
 }
 
 // POST /admin/block-reqs - blocks or unblocks login requests

--- a/server/router/init.go
+++ b/server/router/init.go
@@ -170,7 +170,7 @@ func NewRouter(db *mongo.Database, logger *logging.Logger) *gin.Engine {
 	// Project expo routes
 	defaultRouter.GET("/project/list/public", ListPublicProjects)
 	defaultRouter.GET("/challenges", GetChallenges)
-	defaultRouter.GET("/group-names", GetGroupNames)
+	defaultRouter.GET("/group-info", GetGroupInfo)
 
 	// ######################
 	// ##### END ROUTES #####


### PR DESCRIPTION
### Description

- Judge row action dropdown: the wrong text is red (should be the "delete" text)
- Group names now show up on the expo page, not just on the print page
- Fix overflowing of CSV on upload filename field
- Make CSV preview scroll at 500px
- Made "Move Group" text the same pluralization on projects/judge row
- Fix swap groups message
- Remove disabling of swap groups when judging is running
- Starting deliberation now pauses judging
- Fix weird button sizing on actions menu

### Fixes #286 

### Fixes #288 

### Fixes #289 

### Fixes #296 

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Is this a breaking change?

- [ ] Yes
- [X] No
