### PR TITLE
Fix usage BulkWrite causing runtime errors when there are no judges

### DIFF
--- a/server/judging/scoring.go
+++ b/server/judging/scoring.go
@@ -57,6 +57,11 @@ func InitAggregateRankings(db *mongo.Database) error {
 			return err
 		}
 
+		// Early return if no judges exist
+		if len(judges) == 0 {
+			return nil
+		}
+
 		// Use bulk write to update all judges' aggregated rankings
 		models := make([]mongo.WriteModel, 0, len(judges))
 		for _, judge := range judges {


### PR DESCRIPTION
### Description

On startup the server calls `InitAggregateRankings` which calls `BulkWrite` with nothing when there are no judges (e.g. fresh instance). This returns an error (specifically, `ErrEmptySlice`):
```
Sep 09 02:11:24  2025/09/09 02:11:24 error re-calculating aggregate rankings for all judges: must provide at least one element in input slice
```

From the Swamp, happy hacking. 🐊

### Fixes #303 

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)

### Is this a breaking change?

- [ ] Yes
- [x] No
