### PR TITLE
Move groups based on active projects

### DIFF
--- a/server/database/project.go
+++ b/server/database/project.go
@@ -277,9 +277,8 @@ func DecrementProjectSeenCount(db *mongo.Database, ctx context.Context, project 
 }
 
 // GetNumProjectsInGroup returns the number of projects in a group
-// TODO: Can we pre-aggregate this value?
 func GetNumProjectsInGroup(db *mongo.Database, ctx context.Context, group int64) (int64, error) {
-	return db.Collection("projects").CountDocuments(ctx, gin.H{"group": group})
+	return db.Collection("projects").CountDocuments(ctx, gin.H{"group": group, "active": true})
 }
 
 // GetChallenges gets the list of all challenges from the database


### PR DESCRIPTION
### Description

Ignores inactive projects when calculating the number of projects needed to be seen when using auto-switching for groups with a proportion set.

### Fixes #307 

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)

### Is this a breaking change?

- [ ] Yes
- [X] No
