### PR TITLE
Add judge notes view per project for admin

### DIFF
--- a/client/src/components/admin/tables/ProjectNotesPopup.tsx
+++ b/client/src/components/admin/tables/ProjectNotesPopup.tsx
@@ -1,0 +1,50 @@
+import { useAdminStore } from '../../../store';
+import InfoPopup from '../../InfoPopup';
+
+interface ProjectNotesPopupProps {
+    enabled: boolean;
+    setEnabled: React.Dispatch<React.SetStateAction<boolean>>;
+    project: Project;
+}
+
+const ProjectNotesPopup = (props: ProjectNotesPopupProps) => {
+    const judges = useAdminStore((state) => state.judges);
+
+    const judgeNotes = judges
+        .map((judge) => {
+            const seenProject = judge.seen_projects.find(
+                (sp) => sp.project_id === props.project.id
+            );
+            if (seenProject && seenProject.notes && seenProject.notes.trim() !== '') {
+                return { judgeName: judge.name, notes: seenProject.notes };
+            }
+            return null;
+        })
+        .filter((entry): entry is { judgeName: string; notes: string } => entry !== null);
+
+    return (
+        <InfoPopup
+            enabled={props.enabled}
+            setEnabled={props.setEnabled}
+            title={`Notes for ${props.project.name}`}
+            submitText="Close"
+        >
+            <div className="flex flex-col px-4 items-center my-4">
+                {judgeNotes.length === 0 ? (
+                    <p className="text-lighter">
+                        No judges have left notes for this project.
+                    </p>
+                ) : (
+                    judgeNotes.map((entry, idx) => (
+                        <div key={idx} className="w-full mb-4">
+                            <h2 className="text-primary font-bold">{entry.judgeName}</h2>
+                            <p className="text-light">{entry.notes}</p>
+                        </div>
+                    ))
+                )}
+            </div>
+        </InfoPopup>
+    );
+};
+
+export default ProjectNotesPopup;

--- a/client/src/components/admin/tables/ProjectRow.tsx
+++ b/client/src/components/admin/tables/ProjectRow.tsx
@@ -9,6 +9,7 @@ import { twMerge } from 'tailwind-merge';
 import ActionsDropdown from '../../ActionsDropdown';
 import MoveGroupPopup from './MoveGroupPopup';
 import MovePopup from './MovePopup';
+import ProjectNotesPopup from './ProjectNotesPopup';
 
 interface ProjectRowProps {
     project: Project;
@@ -24,6 +25,7 @@ const ProjectRow = ({ project, idx }: ProjectRowProps) => {
     const [deletePopup, setDeletePopup] = useState(false);
     const [moveGroupPopup, setMoveGroupPopup] = useState(false);
     const [movePopup, setMovePopup] = useState(false);
+    const [notesPopup, setNotesPopup] = useState(false);
     const fetchProjects = useAdminStore((state) => state.fetchProjects);
     const options = useOptionsStore((state) => state.options);
     const track = useOptionsStore((state) => state.selectedTrack);
@@ -147,6 +149,7 @@ const ProjectRow = ({ project, idx }: ProjectRowProps) => {
                         setOpen={setPopup}
                         actions={[
                             'Edit',
+                            'Notes',
                             project.active ? 'Hide' : 'Unhide',
                             project.prioritized ? 'Unprioritize' : 'Prioritize',
                             'Move Table',
@@ -155,13 +158,14 @@ const ProjectRow = ({ project, idx }: ProjectRowProps) => {
                         ]}
                         actionFunctions={[
                             setEditPopup.bind(null, true),
+                            setNotesPopup.bind(null, true),
                             hideProject,
                             prioritizeProject,
                             setMovePopup.bind(null, true),
                             setMoveGroupPopup.bind(null, true),
                             setDeletePopup.bind(null, true),
                         ]}
-                        redIndices={[5]}
+                        redIndices={[6]}
                     />
                     <div
                         className="cursor-pointer hover:text-primary duration-150 mr-2"
@@ -182,6 +186,7 @@ const ProjectRow = ({ project, idx }: ProjectRowProps) => {
             <EditProjectPopup enabled={editPopup} setEnabled={setEditPopup} project={project} />
             <MovePopup enabled={movePopup} setEnabled={setMovePopup} item={project} />
             <MoveGroupPopup enabled={moveGroupPopup} setEnabled={setMoveGroupPopup} item={project} isProject />
+            <ProjectNotesPopup enabled={notesPopup} setEnabled={setNotesPopup} project={project} />
         </>
     );
 };


### PR DESCRIPTION
### Description

There's currently no way to see notes the judges write on the projects on the admin side. The "/judge/list" already pulls that data, I am just rendering it as a popup for admins. Mb Micheal yes ik I did not fork... 

UI Changes:
<img width="135" height="250" alt="Screenshot 2026-02-20 at 3 27 14 PM" src="https://github.com/user-attachments/assets/c0f0d175-f1e9-4475-adb0-c013476be53b" />
<img width="1140" height="394" alt="Screenshot 2026-02-20 at 3 27 20 PM" src="https://github.com/user-attachments/assets/4c3368a6-26f3-4df2-a32c-b240e7e9e502" />

### Fixes #316 

### Type of Change

Delete options that do not apply:
- New feature (non-breaking change which adds functionality)

### Is this a breaking change?

- [ ] Yes
- [x] No 
