### PR TITLE
Added login as judge action in the admin dashboard

### DIFF
--- a/client/src/components/admin/tables/JudgeRow.tsx
+++ b/client/src/components/admin/tables/JudgeRow.tsx
@@ -8,6 +8,7 @@ import { twMerge } from 'tailwind-merge';
 import ActionsDropdown from '../../ActionsDropdown';
 import MoveGroupPopup from './MoveGroupPopup';
 import JudgeRanksPopup from './JudgeRanksPopup';
+import { useNavigate } from 'react-router-dom';
 
 interface JudgeRowProps {
     judge: Judge;
@@ -27,6 +28,7 @@ const JudgeRow = ({ judge, idx }: JudgeRowProps) => {
     const selected = useAdminTableStore((state) => state.selected);
     const setSelected = useAdminTableStore((state) => state.setSelected);
     const projects = useAdminStore((state) => state.projects);
+    const navigate = useNavigate();
 
     useEffect(() => {
         function closeClick(event: MouseEvent) {
@@ -61,6 +63,10 @@ const JudgeRow = ({ judge, idx }: JudgeRowProps) => {
         alert(`Judge ${judge.active ? 'hidden' : 'un-hidden'} successfully!`);
         fetchJudges();
     };
+
+    const loginAsJudge = () => {
+        navigate(`/judge/login?code=${judge.code}`);
+    }
 
     const idToProj = (id: string) => {
         if (!id || id === '') {
@@ -103,15 +109,16 @@ const JudgeRow = ({ judge, idx }: JudgeRowProps) => {
                     <ActionsDropdown
                         open={popup}
                         setOpen={setPopup}
-                        actions={['Scores', 'Edit', judge.active ? 'Hide' : 'Unhide', 'Move Group', 'Delete']}
+                        actions={['Scores', 'Edit', judge.active ? 'Hide' : 'Unhide', 'Move Group', 'Login', 'Delete']}
                         actionFunctions={[
                             setRanksPopup.bind(null, true),
                             setEditPopup.bind(null, true),
                             hideJudge,
                             setMovePopup.bind(null, true),
+                            loginAsJudge,
                             setDeletePopup.bind(null, true),
                         ]}
-                        redIndices={[4]}
+                        redIndices={[5]}
                     />
                     <span
                         className="cursor-pointer px-1 hover:text-primary duration-150"

--- a/client/src/components/admin/tables/JudgeRow.tsx
+++ b/client/src/components/admin/tables/JudgeRow.tsx
@@ -109,7 +109,7 @@ const JudgeRow = ({ judge, idx }: JudgeRowProps) => {
                     <ActionsDropdown
                         open={popup}
                         setOpen={setPopup}
-                        actions={['Scores', 'Edit', judge.active ? 'Hide' : 'Unhide', 'Move Group', 'Login', 'Delete']}
+                        actions={['Scores', 'Edit', judge.active ? 'Hide' : 'Unhide', 'Move Group', 'Login as Judge', 'Delete']}
                         actionFunctions={[
                             setRanksPopup.bind(null, true),
                             setEditPopup.bind(null, true),


### PR DESCRIPTION
### Description

This adds an easy way for an admin to log in as a particular judge, such as for debugging. The "/judge/login" route already supports filling the code in automatically so it's a simple redirect.

The option appears under the actions menu as follows:

<img width="136" height="223" alt="image" src="https://github.com/user-attachments/assets/eab2af70-d349-46ed-8c9d-276474be5544" />

### Fixes #312

### Type of Change

Delete options that do not apply:

- New feature (non-breaking change which adds functionality)

### Is this a breaking change?

- [ ] Yes
- [x] No
