### PR TITLE
fix: percent-encode track name in expo navigation

### DIFF
--- a/client/src/pages/Expo.tsx
+++ b/client/src/pages/Expo.tsx
@@ -123,7 +123,9 @@ const Expo = () => {
                     selected={track}
                     setSelected={setTrack}
                     onChange={(t) => {
-                        navigate('/expo/' + t.replace(/\s/g, '%20'));
+                        // encodeURIComponent handles spaces, slashes, and
+                        // any other reserved URL characters in track names.
+                        navigate('/expo/' + encodeURIComponent(t));
                     }}
                     options={challenges ?? []}
                     className="my-2 md:mx-0 mx-4"


### PR DESCRIPTION
### Description

The expo dropdown built the track URL with `t.replace(/\s/g, '%20')`, which only escapes spaces. A track name containing a slash (e.g. "AI/ML") got navigated to /expo/AI/ML, which the route /expo/:track interpreted as nested path segments and failed to match. Use encodeURIComponent so spaces, slashes, and any other reserved URL characters survive round-tripping through React Router.

### Fixes #315 

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)

### Is this a breaking change?

- [ ] Yes
- [x] No
