### PR TITLE
Reject empty QR codes to close signup auth bypass

### DIFF
--- a/server/router/admin.go
+++ b/server/router/admin.go
@@ -632,8 +632,8 @@ func CheckQRCode(ctx *gin.Context) {
 		return
 	}
 
-	// Send OK if QR code is right
-	if options.QRCode == qrReq.Code {
+	// Send OK or reject empty values
+	if qrReq.Code != "" && options.QRCode != "" && options.QRCode == qrReq.Code {
 		ctx.JSON(http.StatusOK, gin.H{"ok": 1})
 	} else {
 		ctx.JSON(http.StatusOK, gin.H{"ok": 0})
@@ -663,8 +663,9 @@ func CheckTrackQRCode(ctx *gin.Context) {
 		return
 	}
 
-	// Send OK if QR code is right
-	if options.TrackQRCodes[track] == qrReq.Code {
+	// Send OK or reject empty values
+	expected := options.TrackQRCodes[track]
+	if qrReq.Code != "" && expected != "" && expected == qrReq.Code {
 		ctx.JSON(http.StatusOK, gin.H{"ok": 1})
 	} else {
 		ctx.JSON(http.StatusOK, gin.H{"ok": 0})

--- a/server/router/judge.go
+++ b/server/router/judge.go
@@ -1052,17 +1052,14 @@ func AddJudgeFromQR(ctx *gin.Context) {
 			return err
 		}
 
-		// Make sure the code is correct
-		if qrReq.Track == "" {
-			if qrReq.Code != options.QRCode {
-				ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid QR code"})
-				return err
-			}
-		} else {
-			if qrReq.Code != options.TrackQRCodes[qrReq.Track] {
-				ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid QR code"})
-				return err
-			}
+		// Make sure the code is correct and reject empty code
+		expectedCode := options.QRCode
+		if qrReq.Track != "" {
+			expectedCode = options.TrackQRCodes[qrReq.Track]
+		}
+		if qrReq.Code == "" || expectedCode == "" || qrReq.Code != expectedCode {
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid QR code"})
+			return err
 		}
 
 		// Check if the judge already exists


### PR DESCRIPTION
### Description

  The QR-code judge signup flow (`POST /api/qr/add`) authorizes attendees by comparing a submitted code
  against `options.QRCode` (or `options.TrackQRCodes[track]`). Both default to `""` — so before an admin
  generates a QR (or for any track that's never had one set), submitting `{"code": ""}` satisfies `"" !=
  ""` → false and a judge is created with attacker-controlled name/email. Same bypass applies to
  `/api/qr/check` and `/api/qr/check/:track`.
  
### Fixes #[Issue]

Fix: reject empty values explicitly at all three comparison sites in `AddJudgeFromQR`, `CheckQRCode`,
  and `CheckTrackQRCode`.

### Type of Change

Delete options that do not apply:

- Bug fix (change which fixes an issue)

### Is this a breaking change?

- [ ] Yes
- [x] No
